### PR TITLE
Add UTM content tags

### DIFF
--- a/prompt_plan.md
+++ b/prompt_plan.md
@@ -82,7 +82,7 @@ Each chunk (C#) is ≤ 1 dev-day; each step (S#.#) is \~30-90 mins.
 ### C9 — Quota exceeded dialog
 
 * **S9.1** Intercept HTTP 429 / quota header.
-* **S9.2** Show modal dialog; *Upgrade* opens browser `https://doloc.io/account?upgradeToken=…`.
+* **S9.2** Show modal dialog; *Upgrade* opens browser `https://doloc.io/account?upgradeToken=…&utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer&utm_content=quota_dialog`.
 * **S9.3** Log metric to Event Log.
 
 ### C10 — Release engineering
@@ -247,7 +247,7 @@ Handle free-tier limits.
 2. show modal dialog:
    “Quota used up. Upgrade?” with buttons Upgrade / Cancel.
 3. Upgrade button opens browser at
-   `https://doloc.io/account`.
+   `https://doloc.io/account?utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer&utm_content=quota_dialog`.
 ```
 
 ---

--- a/spec.md
+++ b/spec.md
@@ -103,7 +103,7 @@ Configuration is *IDE-level* (affects every project).
   > “Your free translation quota is used up. Create a free doloc account to continue.”
   > Buttons: **Create account** / Cancel
 * **Create account** opens the default browser at
-  `https://doloc.io/account?upgradeToken=<token>`
+  `https://doloc.io/account?upgradeToken=<token>&utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer&utm_content=quota_dialog`
   (backend upgrades the exact same token; no copy-paste needed).
 
 ### 5.3 Opt-in to personal/prod token

--- a/src/main/kotlin/io/doloc/intellij/action/TranslateWithDolocAction.kt
+++ b/src/main/kotlin/io/doloc/intellij/action/TranslateWithDolocAction.kt
@@ -25,6 +25,7 @@ import io.doloc.intellij.service.DolocSettingsService
 import io.doloc.intellij.settings.DolocSettingsState
 import io.doloc.intellij.xliff.LightweightXliffScanner
 import io.doloc.intellij.settings.DolocConfigurable
+import io.doloc.intellij.util.utmUrl
 import java.net.http.HttpResponse
 
 class TranslateWithDolocAction : AnAction("Translate with Auto Localizer") {
@@ -67,7 +68,7 @@ class TranslateWithDolocAction : AnAction("Translate with Auto Localizer") {
                 NotificationType.ERROR,
                 object : AnAction("Visit doloc.io/account") {
                     override fun actionPerformed(e: AnActionEvent) {
-                        BrowserUtil.browse("https://doloc.io/account")
+                        BrowserUtil.browse(utmUrl("https://doloc.io/account", "action_no_token"))
                     }
                 },
                 object : AnAction("Open Settings") {
@@ -169,7 +170,7 @@ class TranslateWithDolocAction : AnAction("Translate with Auto Localizer") {
                             NotificationType.ERROR,
                             object : AnAction("Visit doloc.io/account") {
                                 override fun actionPerformed(e: AnActionEvent) {
-                                    BrowserUtil.browse("https://doloc.io/account")
+                                    BrowserUtil.browse(utmUrl("https://doloc.io/account", "action_quota_exceeded"))
                                 }
                             }
                         )

--- a/src/main/kotlin/io/doloc/intellij/settings/DolocConfigurable.kt
+++ b/src/main/kotlin/io/doloc/intellij/settings/DolocConfigurable.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.options.Configurable
 import com.intellij.ui.components.labels.LinkLabel
 import com.intellij.util.ui.JBUI
 import io.doloc.intellij.service.DolocSettingsService
+import io.doloc.intellij.util.utmUrl
 import java.awt.BorderLayout
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -54,7 +55,7 @@ class DolocConfigurable : Configurable {
         val settingsState = DolocSettingsState.getInstance()
         val (xliff12Panel, xliff12Checkboxes, xliff12Radios) = createXliffSettingsSection(
             "XLIFF 1.2",
-            "https://doloc.io/getting-started/formats/xliff-1-2/",
+            utmUrl("https://doloc.io/getting-started/formats/xliff-1-2/", "settings_xliff12"),
             getXliff12UntranslatedStates(),
             getXliff12NewStateOptions(),
             settingsState.xliff12UntranslatedStates,
@@ -72,7 +73,7 @@ class DolocConfigurable : Configurable {
         // 4. XLIFF 2.0 Settings Section
         val (xliff20Panel, xliff20Checkboxes, xliff20Radios) = createXliffSettingsSection(
             "XLIFF 2.0",
-            "https://doloc.io/getting-started/formats/xliff-2-0/",
+            utmUrl("https://doloc.io/getting-started/formats/xliff-2-0/", "settings_xliff20"),
             getXliff20UntranslatedStates(),
             getXliff20NewStateOptions(),
             settingsState.xliff20UntranslatedStates,
@@ -150,7 +151,7 @@ class DolocConfigurable : Configurable {
         gbc.gridy++
         val linkLabel = LinkLabel<Any?>("Get your token on doloc.io/account", null).apply {
             setListener({ _, _ ->
-                BrowserUtil.browse("https://doloc.io/account")
+                BrowserUtil.browse(utmUrl("https://doloc.io/account", "settings_get_token"))
             }, null)
         }
         panel.add(linkLabel, gbc)

--- a/src/main/kotlin/io/doloc/intellij/util/UrlUtils.kt
+++ b/src/main/kotlin/io/doloc/intellij/util/UrlUtils.kt
@@ -1,0 +1,15 @@
+package io.doloc.intellij.util
+
+/** Base UTM parameters appended to all doloc.io links. */
+const val BASE_UTM: String = "utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer"
+
+/**
+ * Returns the given [base] URL with UTM tracking parameters.
+ *
+ * @param base    the base URL
+ * @param content the utm_content value
+ */
+fun utmUrl(base: String, content: String): String {
+    val separator = if (base.contains("?")) "&" else "?"
+    return "$base${separator}$BASE_UTM&utm_content=$content"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
     <name>Auto Localizer</name>
 
     <!-- A displayed Vendor name or Organization ID displayed on the Plugins Page. -->
-    <vendor url="https://doloc.io">Doloc</vendor>
+    <vendor url="https://doloc.io?utm_source=intellij&amp;utm_medium=plugin&amp;utm_campaign=auto_localizer&amp;utm_content=plugin_vendor">Doloc</vendor>
 
     <!-- Description of the plugin displayed on the Plugin Page and IDE Plugin Manager.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-description -->
@@ -23,13 +23,13 @@ High quality localization with one click!</p>
   <li>Supports XLIFF 1.2 and XLIFF 2.0 formats</li>
   <li>Configurable for different translation states (e.g., initial, new, ...)</li>
   <li>Notification for untranslated segments on saving XLIFF files</li>
-  <li>Powered by <a href="https://doloc.io">doloc.io</a>, a translation service that uses AI to provide high-quality translations</li>
+  <li>Powered by <a href="https://doloc.io?utm_source=intellij&amp;utm_medium=plugin&amp;utm_campaign=auto_localizer&amp;utm_content=plugin_description_powered">doloc.io</a>, a translation service that uses AI to provide high-quality translations</li>
   <li>Free for translation files with up to 100 texts</li>
 </ul>
 </p>
 <h3>Getting started:</h3>
 <p>
-1. Create a (free) account on <a href="https://doloc.io">doloc.io</a> (required to get an API key to use the plugin, we are working on anonymous usage without an account).
+1. Create a (free) account on <a href="https://doloc.io?utm_source=intellij&amp;utm_medium=plugin&amp;utm_campaign=auto_localizer&amp;utm_content=plugin_description_signup">doloc.io</a> (required to get an API key to use the plugin, we are working on anonymous usage without an account).
 2. To configure, open <b>File | Settings | Tools | Auto Localizer</b>.
 </p>
   ]]></description>


### PR DESCRIPTION
## Summary
- generate tracking parameters with a helper
- mark each link with a unique `utm_content`
- escape XML ampersands in `plugin.xml`
- centralize UTM helper

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68811a9f74c0832c86ecda0b8e544441