### PR TITLE
Add anonymous token support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 }
 
 group = "io.doloc"
-version = "1.0.2"
 
 repositories {
     mavenCentral()
@@ -38,12 +37,6 @@ intellijPlatform {
             sinceBuild = "232"
             untilBuild = provider { null }
         }
-
-        changeNotes = """
-      1.0.2
-      - Use settings in translation query
-      - Detect XLIFF version automatically
-    """.trimIndent()
     }
 }
 

--- a/src/main/kotlin/io/doloc/intellij/auth/AnonymousTokenManager.kt
+++ b/src/main/kotlin/io/doloc/intellij/auth/AnonymousTokenManager.kt
@@ -29,7 +29,7 @@ class AnonymousTokenManager(
      */
     suspend fun getOrCreateToken(): String {
         // First check if we already have a token
-        val existingToken = settingsService.getStoredToken()
+        val existingToken = settingsService.getStoredAnonymousToken()
         if (!existingToken.isNullOrBlank()) {
             return existingToken
         }
@@ -38,9 +38,8 @@ class AnonymousTokenManager(
 
         // Create a new anonymous token
         val request = HttpRequest.newBuilder()
-            .uri(URI("$baseUrl/tokens/anonymous"))
-            .header("Content-Type", "application/json")
-            .POST(HttpRequest.BodyPublishers.noBody())
+            .uri(URI("$baseUrl/token/anonymous"))
+            .PUT(HttpRequest.BodyPublishers.noBody())
             .build()
 
         val client = HttpClientProvider.client
@@ -53,7 +52,7 @@ class AnonymousTokenManager(
         val tokenResponse = json.decodeFromString<AnonymousTokenResponse>(response.body())
 
         // Save the new token
-        settingsService.setApiToken(tokenResponse.token)
+        settingsService.setAnonymousToken(tokenResponse.token)
 
         log.info("Created anonymous token with quota: ${tokenResponse.quota}")
         return tokenResponse.token

--- a/src/main/kotlin/io/doloc/intellij/auth/AnonymousTokenManager.kt
+++ b/src/main/kotlin/io/doloc/intellij/auth/AnonymousTokenManager.kt
@@ -1,6 +1,5 @@
 package io.doloc.intellij.auth
 
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.diagnostic.Logger
 import io.doloc.intellij.http.HttpClientProvider
 import io.doloc.intellij.service.DolocSettingsService
@@ -13,7 +12,7 @@ import java.net.http.HttpResponse
 @Serializable
 private data class AnonymousTokenResponse(
     val token: String,
-    val quota: Int
+    val user_id: String
 )
 
 class AnonymousTokenManager(
@@ -45,7 +44,7 @@ class AnonymousTokenManager(
         val client = HttpClientProvider.client
         val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-        if (response.statusCode() != 200) {
+        if (response.statusCode() >= 300) {
             throw IllegalStateException("Failed to get anonymous token: HTTP ${response.statusCode()}")
         }
 
@@ -54,7 +53,7 @@ class AnonymousTokenManager(
         // Save the new token
         settingsService.setAnonymousToken(tokenResponse.token)
 
-        log.info("Created anonymous token with quota: ${tokenResponse.quota}")
+        log.info("Created anonymous token: $tokenResponse")
         return tokenResponse.token
     }
 }

--- a/src/main/kotlin/io/doloc/intellij/service/DolocSettingsService.kt
+++ b/src/main/kotlin/io/doloc/intellij/service/DolocSettingsService.kt
@@ -20,7 +20,7 @@ class DolocSettingsService {
     private val logger = Logger.getInstance(DolocSettingsService::class.java)
     // Keep the legacy key so existing users don't have to re-enter their token
     private val manualTokenKey = "io.doloc.intellij.apiToken"
-    private val anonymousTokenKey = "io.doloc.intellij.anonymousToken"
+    private val anonymousTokenKey = "io.doloc.intellij.anonymousApiToken"
     private val _tokenFlow = MutableStateFlow<String?>(null) // manual token flow
 
     // Lazy-initialized token manager

--- a/src/main/kotlin/io/doloc/intellij/settings/DolocConfigurable.kt
+++ b/src/main/kotlin/io/doloc/intellij/settings/DolocConfigurable.kt
@@ -7,6 +7,7 @@ import com.intellij.util.ui.JBUI
 import io.doloc.intellij.service.DolocSettingsService
 import io.doloc.intellij.util.utmUrl
 import java.awt.BorderLayout
+import java.awt.FlowLayout
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.GridLayout
@@ -132,7 +133,7 @@ class DolocConfigurable : Configurable {
         gbc.gridy++
         gbc.insets = JBUI.insets(5, 20, 0, 0) // Indentation
 
-        val radioPanel = JPanel()
+        val radioPanel = JPanel(FlowLayout(FlowLayout.LEFT))
         anonymousRadio = JRadioButton("Anonymous Token")
         manualRadio = JRadioButton("Manual Token")
         val group = ButtonGroup()
@@ -144,6 +145,7 @@ class DolocConfigurable : Configurable {
 
         gbc.gridy++
         val tokenPanel = JPanel(BorderLayout())
+        tokenPanel.add(JLabel("Manual Token:"), BorderLayout.WEST)
         tokenFieldComponent = JPasswordField().apply {
             columns = 30
             settingsService.getStoredManualToken()?.let { text = it }

--- a/src/main/kotlin/io/doloc/intellij/settings/DolocSettingsState.kt
+++ b/src/main/kotlin/io/doloc/intellij/settings/DolocSettingsState.kt
@@ -39,6 +39,7 @@ class DolocSettingsState : PersistentStateComponent<DolocSettingsState> {
 
     // Common settings
     var showReminderToast: Boolean = true
+    var useAnonymousToken: Boolean = true
 
     override fun getState(): DolocSettingsState = this
 

--- a/src/main/kotlin/io/doloc/intellij/util/UrlUtils.kt
+++ b/src/main/kotlin/io/doloc/intellij/util/UrlUtils.kt
@@ -10,6 +10,12 @@ const val BASE_UTM: String = "utm_source=intellij&utm_medium=plugin&utm_campaign
  * @param content the utm_content value
  */
 fun utmUrl(base: String, content: String): String {
-    val separator = if (base.contains("?")) "&" else "?"
-    return "$base${separator}$BASE_UTM&utm_content=$content"
+    val parts = base.split('#', limit = 2)
+    val path = parts[0]
+    val fragment = parts.getOrNull(1)
+
+    val separator = if (path.contains('?')) "&" else "?"
+    val urlWithParams = "$path${separator}$BASE_UTM&utm_content=$content"
+
+    return if (fragment != null) "$urlWithParams#$fragment" else urlWithParams
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,6 +2,7 @@
 <idea-plugin>
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
     <id>io.doloc.auto-localizer</id>
+    <version>1.1.0</version>
 
     <!-- Public plugin name should be written in Title Case.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
@@ -24,15 +25,34 @@ High quality localization with one click!</p>
   <li>Configurable for different translation states (e.g., initial, new, ...)</li>
   <li>Notification for untranslated segments on saving XLIFF files</li>
   <li>Powered by <a href="https://doloc.io?utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer&utm_content=plugin_description_powered">doloc.io</a>, a translation service that uses AI to provide high-quality translations</li>
-  <li>Free for translation files with up to 100 texts</li>
+  <li>Free and without registration for translation files with up to 100 texts</li>
 </ul>
 </p>
 <h3>Getting started:</h3>
 <p>
-1. Create a (free) account on <a href="https://doloc.io?utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer&utm_content=plugin_description_signup">doloc.io</a> (required to get an API key to use the plugin, we are working on anonymous usage without an account).
-2. To configure, open <b>File | Settings | Tools | Auto Localizer</b>.
+<ol>
+    <li>Right-click on an XLIFF file in the Project View or Editor</li>
+    <li>Select "Translate with Auto Localizer" from the context menu</li>
+    <li>The plugin will automatically translate the segments in the file using the doloc service</li>
+    <li>To configure, open <b>File | Settings | Tools | Auto Localizer</b></li>
+</ol>
+
+Optionally:
+<ul>
+  <li>Create a (free) account on <a href="https://doloc.io?utm_source=intellij&utm_medium=plugin&utm_campaign=auto_localizer&utm_content=plugin_description_signup">doloc.io</a></li>
+  <li>Enter your API key in the settings (apply for a paid plan for larger text quota)</li>
+  <li>Configure the translation state for which the plugin should translate segments</li>
+  <li>Enable/disable the notification for untranslated segments on saving XLIFF files</li>
+</ul>
 </p>
   ]]></description>
+    <change-notes><![CDATA[
+<h2>New Features</h2>
+<ul>
+  <li>Anonymous token support (up to 100 texts without registration)</li>
+  <li>Improved documentation</li>
+</ul>
+    ]]></change-notes>
 
     <!-- Product and plugin compatibility requirements.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->

--- a/src/test/kotlin/io/doloc/intellij/auth/AnonymousTokenManagerTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/auth/AnonymousTokenManagerTest.kt
@@ -41,20 +41,20 @@ class AnonymousTokenManagerTest {
     @Test
     fun `should return existing token if available`() = runBlocking {
         // Setup: mock settings to return an existing token
-        whenever(mockSettingsService.getStoredToken()).thenReturn("existing-token")
+        whenever(mockSettingsService.getStoredAnonymousToken()).thenReturn("existing-token")
 
         // Execute
         val result = tokenManager.getOrCreateToken()
 
         // Verify
         assertEquals("existing-token", result)
-        verify(mockSettingsService, never()).setApiToken("existing-token")
+        verify(mockSettingsService, never()).setAnonymousToken("existing-token")
     }
 
     @Test
     fun `should create and store new anonymous token if none exists`() = runBlocking {
         // Setup: mock settings to return null (no token)
-        whenever(mockSettingsService.getStoredToken()).thenReturn(null)
+        whenever(mockSettingsService.getStoredAnonymousToken()).thenReturn(null)
 
         // Mock the server response
         val responseBody = """{"token":"new-anonymous-token","quota":1000}"""
@@ -70,11 +70,11 @@ class AnonymousTokenManagerTest {
 
         // Verify
         assertEquals("new-anonymous-token", result)
-        verify(mockSettingsService).setApiToken("new-anonymous-token")
+        verify(mockSettingsService).setAnonymousToken("new-anonymous-token")
 
         // Verify the request
         val recordedRequest = mockWebServer.takeRequest()
-        assertEquals("POST", recordedRequest.method)
-        assertEquals("/tokens/anonymous", recordedRequest.path)
+        assertEquals("PUT", recordedRequest.method)
+        assertEquals("/token/anonymous", recordedRequest.path)
     }
 }

--- a/src/test/kotlin/io/doloc/intellij/auth/AnonymousTokenManagerTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/auth/AnonymousTokenManagerTest.kt
@@ -57,7 +57,7 @@ class AnonymousTokenManagerTest {
         whenever(mockSettingsService.getStoredAnonymousToken()).thenReturn(null)
 
         // Mock the server response
-        val responseBody = """{"token":"new-anonymous-token","quota":1000}"""
+        val responseBody = """{"token":"new-anonymous-token","user_id":"1234-1234-1234-1234"}"""
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(200)

--- a/src/test/kotlin/io/doloc/intellij/service/DolocSettingsServiceTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/service/DolocSettingsServiceTest.kt
@@ -1,9 +1,12 @@
 package io.doloc.intellij.service
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.doloc.intellij.settings.DolocSettingsState
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class DolocSettingsServiceTest : BasePlatformTestCase() {
 
@@ -13,11 +16,13 @@ class DolocSettingsServiceTest : BasePlatformTestCase() {
         super.setUp()
         // Use the real service since we're testing integration with PasswordSafe
         service = DolocSettingsService.getInstance()
+        DolocSettingsState.getInstance().useAnonymousToken = false
     }
 
     override fun tearDown() {
         // Clean up after tests
         service.clearApiToken()
+        DolocSettingsState.getInstance().useAnonymousToken = true
         super.tearDown()
     }
 
@@ -59,5 +64,23 @@ class DolocSettingsServiceTest : BasePlatformTestCase() {
             service.clearApiToken()
             assertNull(service.tokenFlow.first())
         }
+    }
+
+    @Test
+    fun testGetApiTokenManualVsAnonymous() {
+        val manualToken = "manual-token"
+        val anonymousToken = "anon-token"
+
+        // Store both tokens
+        service.setApiToken(manualToken)
+        service.setAnonymousToken(anonymousToken)
+
+        // Manual mode should return manual token
+        DolocSettingsState.getInstance().useAnonymousToken = false
+        assertEquals(manualToken, service.getApiToken())
+
+        // Anonymous mode should return anonymous token
+        DolocSettingsState.getInstance().useAnonymousToken = true
+        assertEquals(anonymousToken, service.getApiToken())
     }
 }

--- a/src/test/kotlin/io/doloc/intellij/util/UrlUtilsTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/util/UrlUtilsTest.kt
@@ -1,0 +1,18 @@
+package io.doloc.intellij.util
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertEquals
+
+class UrlUtilsTest {
+    @Test
+    fun `utmUrl places parameters before fragment`() {
+        val url = utmUrl("https://doloc.io/pricing/#source-texts", "test")
+        assertTrue(url.contains(BASE_UTM))
+        assertTrue(url.contains("utm_content=test"))
+        val question = url.indexOf('?')
+        val hash = url.indexOf('#')
+        assertTrue(question in 0 until hash)
+        assertEquals("#source-texts", url.substring(hash))
+    }
+}


### PR DESCRIPTION
## Summary
- support anonymous and manual tokens with persisted toggle
- store manual token under old key to keep compatibility
- show anonymous token quota link with UTM tag
- test manual vs anonymous token selection and translation action

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68872c03748c832cb4e89d58bb768a3a