### PR TITLE
Include response body in translation failure notifications

### DIFF
--- a/src/main/kotlin/io/doloc/intellij/action/TranslateWithDolocAction.kt
+++ b/src/main/kotlin/io/doloc/intellij/action/TranslateWithDolocAction.kt
@@ -200,7 +200,21 @@ class TranslateWithDolocAction : AnAction("Translate with Auto Localizer") {
 
                         }
                     } else {
-                        throw IllegalStateException("Translation failed with status: ${response.statusCode()}")
+                        val responseBody = try {
+                            String(response.body()).trim()
+                        } catch (ignored: Exception) {
+                            ""
+                        }
+
+                        val message = buildString {
+                            append("Translation failed with status: ${response.statusCode()}")
+                            if (responseBody.isNotEmpty()) {
+                                append('\n')
+                                append(responseBody)
+                            }
+                        }
+
+                        throw IllegalStateException(message)
                     }
                 } catch (e: ProcessCanceledException) {
                     throw e

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 <idea-plugin>
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
     <id>io.doloc.auto-localizer</id>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <!-- Public plugin name should be written in Title Case.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
@@ -49,8 +49,7 @@ Optionally:
     <change-notes><![CDATA[
 <h2>New Features</h2>
 <ul>
-  <li>Anonymous token support (up to 100 texts without registration)</li>
-  <li>Improved documentation</li>
+  <li>Improved error handling, including display of specific and actionable error notifications</li>
 </ul>
     ]]></change-notes>
 


### PR DESCRIPTION
## Summary
- include the server response body in translation failure notifications when present
- keep the existing status code context while trimming empty responses

## Testing
- ./gradlew test *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691390ea4d54832cab366066df6a4972)