### PR TITLE
Update plugin metadata for notification opt-out

### DIFF
--- a/src/main/kotlin/io/doloc/intellij/listener/DolocFileListener.kt
+++ b/src/main/kotlin/io/doloc/intellij/listener/DolocFileListener.kt
@@ -104,6 +104,13 @@ class DolocFileListener : BulkFileListener {
             }
         })
 
+        notification.addAction(object : AnAction("Never show this again") {
+            override fun actionPerformed(e: AnActionEvent) {
+                DolocSettingsState.getInstance().showReminderToast = false
+                notification.expire()
+            }
+        })
+
         notification.notify(project)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
 <idea-plugin>
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
     <id>io.doloc.auto-localizer</id>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 
     <!-- Public plugin name should be written in Title Case.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
@@ -50,6 +50,7 @@ Optionally:
 <h2>New Features</h2>
 <ul>
   <li>Improved error handling, including display of specific and actionable error notifications</li>
+  <li>Added a "Never show this again" action to untranslated strings notifications</li>
 </ul>
     ]]></change-notes>
 


### PR DESCRIPTION
## Summary
- bump the plugin version to 1.2.0
- document the new notification opt-out action in the change notes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691447106628832cba2e61e0bc8f34dc)