### PR TITLE
feat: add plugin version headers to API requests

### DIFF
--- a/src/main/kotlin/io/doloc/intellij/api/DolocRequestBuilder.kt
+++ b/src/main/kotlin/io/doloc/intellij/api/DolocRequestBuilder.kt
@@ -5,6 +5,7 @@ import io.doloc.intellij.service.DolocSettingsService
 import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.net.http.HttpRequest
+import java.net.http.HttpRequest.Builder
 
 /**
  * Builds HTTP requests for doloc API
@@ -36,6 +37,7 @@ object DolocRequestBuilder {
             .uri(URI("$BASE_URL$queryString"))
             .header("Authorization", "Bearer $token")
             .header("Accept", "application/octet-stream")
+            .addPluginHeaders()
             .POST(HttpRequest.BodyPublishers.ofByteArray(filePath.contentsToByteArray()))
             .build()
     }
@@ -82,6 +84,7 @@ object DolocRequestBuilder {
             .header("Authorization", "Bearer $token")
             .header("Accept", "application/octet-stream")
             .header("Content-Type", "multipart/form-data; boundary=$boundary")
+            .addPluginHeaders()
             .POST(HttpRequest.BodyPublishers.ofByteArray(body))
             .build()
     }
@@ -116,5 +119,10 @@ object DolocRequestBuilder {
         }
         output.write("--$boundary--\r\n".toByteArray())
         return output.toByteArray()
+    }
+
+    private fun Builder.addPluginHeaders(): Builder {
+        return header("User-Agent", DolocRequestMetadata.userAgent())
+            .header(DolocRequestMetadata.VERSION_HEADER_NAME, DolocRequestMetadata.pluginVersion())
     }
 }

--- a/src/main/kotlin/io/doloc/intellij/api/DolocRequestMetadata.kt
+++ b/src/main/kotlin/io/doloc/intellij/api/DolocRequestMetadata.kt
@@ -1,0 +1,35 @@
+package io.doloc.intellij.api
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
+
+object DolocRequestMetadata {
+    private const val PLUGIN_ID = "io.doloc.auto-localizer"
+    private const val USER_AGENT_PRODUCT = "doloc-intellij-plugin"
+    const val VERSION_HEADER_NAME = "X-intellij-plugin-version"
+
+    private val pluginVersion: String by lazy {
+        resolvePluginVersion()
+    }
+
+    fun pluginVersion(): String = pluginVersion
+
+    fun userAgent(): String = "$USER_AGENT_PRODUCT/$pluginVersion"
+
+    private fun resolvePluginVersion(): String {
+        PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))?.version
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        return loadVersionFromPluginXml() ?: "unknown"
+    }
+
+    private fun loadVersionFromPluginXml(): String? {
+        val stream = DolocRequestMetadata::class.java.getResourceAsStream("/META-INF/plugin.xml") ?: return null
+        return stream.bufferedReader().use { reader ->
+            versionTagPattern.find(reader.readText())?.groupValues?.getOrNull(1)
+        }
+    }
+
+    private val versionTagPattern = Regex("<version>\\s*([^<]+?)\\s*</version>")
+}

--- a/src/main/kotlin/io/doloc/intellij/auth/AnonymousTokenManager.kt
+++ b/src/main/kotlin/io/doloc/intellij/auth/AnonymousTokenManager.kt
@@ -2,6 +2,7 @@ package io.doloc.intellij.auth
 
 import com.intellij.openapi.diagnostic.Logger
 import io.doloc.intellij.api.DolocRequestBuilder
+import io.doloc.intellij.api.DolocRequestMetadata
 import io.doloc.intellij.http.HttpClientProvider
 import io.doloc.intellij.service.DolocSettingsService
 import kotlinx.serialization.Serializable
@@ -41,6 +42,8 @@ class AnonymousTokenManager(
 
         val request = HttpRequest.newBuilder()
             .uri(URI("${baseUrlProvider()}/token/anonymous"))
+            .header("User-Agent", DolocRequestMetadata.userAgent())
+            .header(DolocRequestMetadata.VERSION_HEADER_NAME, DolocRequestMetadata.pluginVersion())
             .PUT(HttpRequest.BodyPublishers.noBody())
             .build()
 

--- a/src/test/kotlin/io/doloc/intellij/action/TranslateWithDolocActionTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/action/TranslateWithDolocActionTest.kt
@@ -9,8 +9,10 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.MapDataContext
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import io.doloc.intellij.api.DolocRequestBuilder
+import io.doloc.intellij.api.DolocRequestMetadata
 import io.doloc.intellij.service.DolocSettingsService
 import io.doloc.intellij.settings.DolocSettingsState
+import io.doloc.intellij.test.RecordedRequest
 import io.doloc.intellij.test.TestHttpServer
 import io.doloc.intellij.test.TestResponse
 import java.io.File
@@ -95,6 +97,7 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertEquals("POST", recordedRequest?.method)
         assertTrue(recordedRequest?.path?.startsWith("/") ?: false)
         assertEquals("Bearer test-token", recordedRequest?.getHeader("Authorization"))
+        assertPluginHeaders(recordedRequest)
 
         waitForTranslationResult()
     }
@@ -122,6 +125,7 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertNotNull("No request was recorded", recordedRequest)
         assertEquals("POST", recordedRequest?.method)
         assertEquals("Bearer anon-token", recordedRequest?.getHeader("Authorization"))
+        assertPluginHeaders(recordedRequest)
 
         waitForTranslationResult()
     }
@@ -155,11 +159,13 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertNotNull(tokenRequest)
         assertEquals("PUT", tokenRequest?.method)
         assertEquals("/token/anonymous", tokenRequest?.path)
+        assertPluginHeaders(tokenRequest)
 
         val translationRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS)
         assertNotNull(translationRequest)
         assertEquals("POST", translationRequest?.method)
         assertEquals("Bearer new-anonymous-token", translationRequest?.getHeader("Authorization"))
+        assertPluginHeaders(translationRequest)
         assertEquals("new-anonymous-token", settingsService.getStoredAnonymousToken())
 
         waitForTranslationResult()
@@ -182,6 +188,7 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertNotNull("No request was recorded", recordedRequest)
         assertEquals("POST", recordedRequest?.method)
         assertEquals("Bearer test-token", recordedRequest?.getHeader("Authorization"))
+        assertPluginHeaders(recordedRequest)
 
         waitForTranslationResult()
     }
@@ -222,16 +229,19 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertNotNull(firstRequest)
         assertEquals("POST", firstRequest?.method)
         assertEquals("Bearer anon-token", firstRequest?.getHeader("Authorization"))
+        assertPluginHeaders(firstRequest)
 
         val tokenRefreshRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS)
         assertNotNull(tokenRefreshRequest)
         assertEquals("PUT", tokenRefreshRequest?.method)
         assertEquals("/token/anonymous", tokenRefreshRequest?.path)
+        assertPluginHeaders(tokenRefreshRequest)
 
         val retriedRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS)
         assertNotNull(retriedRequest)
         assertEquals("POST", retriedRequest?.method)
         assertEquals("Bearer refreshed-anon-token", retriedRequest?.getHeader("Authorization"))
+        assertPluginHeaders(retriedRequest)
         assertEquals("refreshed-anon-token", settingsService.getStoredAnonymousToken())
 
         waitForTranslationResult()
@@ -251,6 +261,7 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertNotNull(recordedRequest)
         assertEquals("POST", recordedRequest?.method)
         assertEquals("Bearer test-token", recordedRequest?.getHeader("Authorization"))
+        assertPluginHeaders(recordedRequest)
         assertNull(mockWebServer.takeRequest(1, TimeUnit.SECONDS))
     }
 
@@ -338,6 +349,15 @@ class TranslateWithDolocActionTest : BasePlatformTestCase() {
         assertTrue(
             "File should contain translation state='translated'",
             VfsUtil.loadText(xliffFile).contains("state=\"translated\"")
+        )
+    }
+
+    private fun assertPluginHeaders(request: RecordedRequest?) {
+        val recordedRequest = requireNotNull(request)
+        assertEquals(DolocRequestMetadata.userAgent(), recordedRequest.getHeader("User-Agent"))
+        assertEquals(
+            DolocRequestMetadata.pluginVersion(),
+            recordedRequest.getHeader(DolocRequestMetadata.VERSION_HEADER_NAME)
         )
     }
 }

--- a/src/test/kotlin/io/doloc/intellij/arb/ArbRequestBuilderTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/arb/ArbRequestBuilderTest.kt
@@ -3,6 +3,7 @@ package io.doloc.intellij.arb
 import com.intellij.mock.MockVirtualFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import io.doloc.intellij.api.DolocRequestBuilder
+import io.doloc.intellij.api.DolocRequestMetadata
 import io.doloc.intellij.service.DolocSettingsService
 import io.doloc.intellij.settings.DolocSettingsState
 import java.net.http.HttpRequest
@@ -42,6 +43,11 @@ class ArbRequestBuilderTest : BasePlatformTestCase() {
 
         assertEquals("POST", request.method())
         assertEquals("Bearer test-token", request.headers().firstValue("Authorization").orElse(null))
+        assertEquals(DolocRequestMetadata.userAgent(), request.headers().firstValue("User-Agent").orElse(null))
+        assertEquals(
+            DolocRequestMetadata.pluginVersion(),
+            request.headers().firstValue(DolocRequestMetadata.VERSION_HEADER_NAME).orElse(null)
+        )
         assertTrue(request.uri().toString().contains("untranslated=missing,empty"))
         assertTrue(request.uri().toString().contains("sourceLang=en"))
         assertTrue(request.uri().toString().contains("targetLang=de"))

--- a/src/test/kotlin/io/doloc/intellij/auth/AnonymousTokenManagerTest.kt
+++ b/src/test/kotlin/io/doloc/intellij/auth/AnonymousTokenManagerTest.kt
@@ -1,5 +1,6 @@
 package io.doloc.intellij.auth
 
+import io.doloc.intellij.api.DolocRequestMetadata
 import io.doloc.intellij.service.DolocSettingsService
 import io.doloc.intellij.test.TestHttpServer
 import io.doloc.intellij.test.TestResponse
@@ -78,5 +79,10 @@ class AnonymousTokenManagerTest {
         kotlin.test.assertNotNull(recordedRequest)
         assertEquals("PUT", recordedRequest.method)
         assertEquals("/token/anonymous", recordedRequest.path)
+        assertEquals(DolocRequestMetadata.userAgent(), recordedRequest.getHeader("User-Agent"))
+        assertEquals(
+            DolocRequestMetadata.pluginVersion(),
+            recordedRequest.getHeader(DolocRequestMetadata.VERSION_HEADER_NAME)
+        )
     }
 }

--- a/src/test/kotlin/io/doloc/intellij/test/TestHttpServer.kt
+++ b/src/test/kotlin/io/doloc/intellij/test/TestHttpServer.kt
@@ -73,5 +73,8 @@ data class RecordedRequest(
     val headers: Map<String, List<String>>,
     val body: String
 ) {
-    fun getHeader(name: String): String? = headers[name]?.firstOrNull()
+    fun getHeader(name: String): String? = headers.entries
+        .firstOrNull { (headerName, _) -> headerName.equals(name, ignoreCase = true) }
+        ?.value
+        ?.firstOrNull()
 }


### PR DESCRIPTION
## Summary
- add a shared request metadata helper that resolves the installed plugin version and formats `User-Agent` plus `X-intellij-plugin-version`
- attach the plugin version headers to translation and anonymous token requests so backend logging can attribute traffic to plugin releases
- extend request tests and make the test HTTP server treat headers case-insensitively to match real HTTP behavior

## Testing
- gradle test --tests \"io.doloc.intellij.action.TranslateWithDolocActionTest\" --tests \"io.doloc.intellij.arb.ArbRequestBuilderTest\" --tests \"io.doloc.intellij.auth.AnonymousTokenManagerTest\"